### PR TITLE
Change color of selected shortcut

### DIFF
--- a/A Scanner Darkly.alfredappearance
+++ b/A Scanner Darkly.alfredappearance
@@ -10,7 +10,7 @@
       },
       "shortcut" : {
         "size" : 16,
-        "colorSelected" : "#A9A9A9FF",
+        "colorSelected" : "#FEFFFFFF",
         "font" : "Helvetica Neue Light",
         "color" : "#A9A9A9FF"
       },

--- a/Neon Dark.alfredappearance
+++ b/Neon Dark.alfredappearance
@@ -10,7 +10,7 @@
       },
       "shortcut" : {
         "size" : 16,
-        "colorSelected" : "#919191FF",
+        "colorSelected" : "#000000FF",
         "font" : "Helvetica Neue Light",
         "color" : "#A9A9A9FF"
       },


### PR DESCRIPTION
This changes the color of the selected shortcut to black for “Neon
Dark” and white for “A Scanner Darkly”.